### PR TITLE
Missing page in document index & conflicting Glossary table ID

### DIFF
--- a/architecture.adoc
+++ b/architecture.adoc
@@ -21,6 +21,8 @@ include::architecture/01_introduction_and_goals/04_features_traceability_matrix.
 
 include::architecture/01_introduction_and_goals/05_risks_tech-debt.adoc[]
 
+include::architecture/01_introduction_and_goals/06_glossary.adoc[]
+
 // decrease back to heading2
 :leveloffset: -1
 include::architecture/02_architecture/index.adoc[]

--- a/architecture/01_introduction_and_goals/06_glossary.adoc
+++ b/architecture/01_introduction_and_goals/06_glossary.adoc
@@ -6,7 +6,7 @@ The glossary explains terminology and allows to reference acronyms easily. Copy 
 ////
 
 
-[cols="1,8", id=stakeholders, options="header"]
+[cols="1,8", id=glossary, options="header"]
 |===
 |Term |Description
 


### PR DESCRIPTION
fix (page): conflicting table id + implement glossary page in architecture index